### PR TITLE
link to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,55 +10,16 @@ To be included, items must:
 Note : TBD, make link here to "how to contribute to tools documentation"; fill in missing details below.
 	
 ## Auth & File Access Tools
-* **[Solid Auth Client](https://github.com/solid/solid-auth-client)**
-\- A browser library for reading and writing to Solid pods
-\- by [Ruben Verborgh](https://ruben.verborgh.org/)
-* **[Solid Cli](https://github.com/solid/solid-cli)**
-\- A utility to facilitate command-line interaction with Solid servers
-\- by [Ruben Verborgh](https://ruben.verborgh.org/)
-* **[Solid Auth Cli](https://github.com/jeff-zucker/solid-auth-cli)**
-\- A node/command-line Solid client with persistent login
-\- by [Jeff Zucker](https://github.com/jeff-zucker/)
-* **[Solid File Client](https://github.com/jeff-zucker/solid-file-client)**
-\- Create and manage files and folders in Solid Pods
-\- by [Jeff Zucker](https://github.com/jeff-zucker/)
-* **[Solid-Rest](https://github.com/jeff-zucker/solid-rest)**
-* **[Solid-Local-Pod-Manager](https://github.com/otto-aa/solid-local-pod-manager)**
+
+This section was moved to https://solid.github.io/for-developers/apps/tools
 
 ## RDF Creating, Parsing, Querying Tools
-* **[rdflib.js](https://github.com/linkeddata/rdflib.js)**
-\- Javascript RDF library for browsers and Node.js
-\- by [LinkedData](https://github.com/linkeddata/rdflib.js/)
-* **[LDFlex for Solid](https://github.com/solid/query-ldflex)**
-\- Simple access to data in Solid pods through LDflex expressions
-\- by [Ruben Verborgh](https://ruben.verborgh.org/)
-* **[Sparql Fiddle](https://github.com/jeff-zucker/sparql-fiddle)**
-\- A JavaScript SPARQL API for Solid Pods
-\- by [Jeff Zucker](https://github.com/jeff-zucker/)
-* **[Comunica](https://github.com/comunica/comunica)**
-\- A highly modular and flexible meta query engine for the Web
-\- by [Ruben Taelman](https://www.rubensworks.net/)
-* **[GraphQL-LD for Solid](https://github.com/rubensworks/graphql-ld-comunica-solid.js)**
-\- A GraphQL-LD engine with Solid authentication 
-\- by [Ruben Taelman](https://www.rubensworks.net/)
-* **[Tripledoc](https://vincenttunru.gitlab.io/tripledoc/)**
-\- A library for easy manipulation on RDF
-* **[rdf-ext](https://github.com/rdf-ext/rdf-ext)**
-\- An implementation of RDFJS specifications
-* **[RDF-Easy](https://github.com/jeff-zucker/rdf-easy)**
-* **[Soukai-solid](https://github.com/NoelDeMartin/soukai-solid)**
+
+This section was moved to https://solid.github.io/for-developers/apps/tools
 
 ## Libraries and Toolkits for React
 
-* **[Solid React Components](https://github.com/solid/react-components)**
-\- Basic React components for building your own Solid components and apps
-\- by [Ruben Verborgh](https://ruben.verborgh.org/)
-* **[React SDK for Solid](https://github.com/inrupt-inc/solid-react-sdk)**
-\- Libraries, components, documentation, best practices, and an application generator to accelerate development of high-quality Solid applications
-\- by [inrupt](https://www.inrupt.com)
-* **[GraphQL-LD Solid React Components](https://github.com/rubensworks/solid-react-graphql-ld.js)**
-\- A GraphQL-LD engine with Solid authentication 
-\- by [Ruben Taelman](https://www.rubensworks.net/)
+This section was moved to https://solid.github.io/for-developers/apps/tools
 
 ## Libraries and Toolkits for the Panes UI
 


### PR DESCRIPTION
once updated, we can change 'solid.github.io' to 'solidproject.org', but with this, at least we're already pointing to a single place and no longer have a risk that libraries would be added here and not there.